### PR TITLE
Add depth resolution logic to autoresolver

### DIFF
--- a/lib/assembly/app.js
+++ b/lib/assembly/app.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var fs = require('recur-fs');
-var loader = require('electrolyte').dir;
+var loader = require('../loaders/dir');
 
 
 module.exports = function(options) {

--- a/lib/loaders/dir.js
+++ b/lib/loaders/dir.js
@@ -1,0 +1,51 @@
+// Load modules.
+var scripts = require('scripts')
+  , path = require('path')
+  , fs = require('fs')
+  , resolve = require('require-resolve')
+
+/**
+ * Sources objects from a directory.
+ *
+ * This source allows objects located in a directory on the file system to be
+ * created and injected as dependencies.
+ *
+ * This directory typically contains application-specific objects such as
+ * proprietary classes and non-standardized endpoints.
+ *
+ * Over the course of developing an application, it is normal for objects to
+ * start out as application-specific.  After successive iterations, it is common
+ * for these objects to be factored into reusable classes with well-defined
+ * interfaces.  When that occurs, it is recommended for such classes to be
+ * extracted from the application and packaged in a stand-alone source.
+ *
+ * Unlike vanilla electrolyte dir, bixby-dir attaches @path information 
+ * to assemblies.
+ *
+ * @return {function}
+ * @public
+ */
+module.exports = function (options) {
+  if ('string' == typeof options) {
+    options = { dirname: options }
+  }
+  
+  options = options || {};
+
+  var dirname = options.dirname || 'app'
+    , extensions = options.extensions
+    , dir = path.resolve(dirname);
+
+  return function app(id) {
+    var aid = path.join(dir, id)
+      , script = scripts.resolve(aid, extensions);
+
+    var p = resolve(script, require.main.filename)
+
+    if (p != null) {
+      let module = require(p.src);
+      module['@path'] = p.src
+      return module
+    }
+  };
+};

--- a/lib/loaders/package.js
+++ b/lib/loaders/package.js
@@ -1,15 +1,14 @@
 var path = require('path');
+var resolve = require('require-resolve')
 
 module.exports = function(name, main) {
-  
   return function(id) {
-    var p = path.join(name, main || '.', id);
-    
-    try {
-      return require.main.require(p);
-    } catch (ex) {
-      if (ex.code == 'MODULE_NOT_FOUND') { return; }
-      throw ex;
+    var p = resolve(path.join(name, main || '.', id), require.main.filename)
+
+    if (p != null) {
+      module = require(p.src)
+      module['@path'] = p.src
+      return module
     }
   };
 };

--- a/lib/resolvers/auto.js
+++ b/lib/resolvers/auto.js
@@ -1,5 +1,8 @@
+var path = require('path');
 var flatten = require('utils-flatten');
-
+var readPkg = require('read-pkg-up');
+var resolve = require('require-resolve');
+var pkgDir = require('pkg-dir');
 
 /**
  * Automatic interface resolver.
@@ -11,29 +14,95 @@ var flatten = require('utils-flatten');
  * For consistency and saftey in the development cycle, such resolution succeeds
  * if and only if there is one object within the container that implements the
  * interface.  If multiple objects implement the interface, automatic resolution
- * would be ambiguous, and is therefore not performed.  In such cases, the exact
- * object to resolve can be explicitly declared in configuration.
+ * is solved by selecting the least deep module. If two happen to be exactly 
+ * identical in score, then the ambiguity will raise an error.
  *
  * @return {function}
  * @protected
  */
+
 module.exports = function(container) {
-  
   return function(iface, pid) {
     var specs = container.components()
       , candidates = []
       , spec, i, len;
+
     for (i = 0, len = specs.length; i < len; ++i) {
       spec = specs[i];
       if (spec.implements.indexOf(iface) !== -1) {
-        candidates.push(spec.id);
+        candidates.push({
+          id: spec.id, 
+          moduleDepth: moduleDepth(spec.a['@path']), 
+          pathDepth: pathDepth(spec.a['@path'])
+        });
       }
     }
-    
-    if (candidates.length == 1) {
-      return candidates[0];
-    } else if (candidates.length > 1) {
-      throw new Error('Multiple objects implement interface \"' + iface + '\" required by \"' + (pid || 'unknown') + '\". Configure one of: ' + candidates.join(', '));
+
+    candidates = candidates.sort(scoreCandidates);
+
+    if ( candidates.length > 1 && equalCandidates(candidates[0], candidates[1]) ) {
+      throw new Error('Multiple same rank objects implement interface \"' + iface + '\" required by \"' + (pid || 'unknown') + '\". Configure or remove one of: ' + candidates.map((ea)=>ea.id).join(', '));
+    } else {
+      return candidates[0].id;
     }
   };
 }
+
+/**
+ * moduleDepth
+ *
+ * Version of npm after 2, node_modules
+ * are no longer nested. This function
+ * calculates the depth of a given 
+ * dependency to compensate for the 
+ * loss of information in the fs.
+ *
+ * It recurses up the _requiredBy field
+ * provided by npm@3 and above
+ *
+ * @return {number}
+ */
+function moduleDepth (fPath) {
+  var finalDepth = 0;
+
+  if (fPath.match('node_modules') == -1) {
+    return finalDepth;
+  }
+
+  function recurse (dir, depth) {
+    //TODO: Remove sync
+    var packageDir = pkgDir.sync(resolve(dir).src)
+      , package = readPkg.sync({cwd: packageDir}).pkg;
+
+    if (!package._requiredBy) {
+      return false;
+    } else if (package._requiredBy.indexOf('#USER') !== -1) {
+      finalDepth = depth;
+      return true;
+    }
+    package._requiredBy.map((package)=>recurse(package, depth+1));
+
+  }
+
+  recurse(fPath, 1)
+  return finalDepth
+}
+
+function pathDepth (fPath) {
+  return fPath.split(path.sep).length - require.main.filename.split(path.sep).length;
+}
+
+function scoreCandidates(a,b) {
+  if (a.moduleDepth > b.moduleDepth) {
+    return 1;
+  } else if (a.moduleDepth < b.moduleDepth) {
+    return -1;
+  }
+  return a.pathDepth - b.pathDepth;
+}
+
+function equalCandidates (a,b) {
+  return a.pathDepth === b.pathDepth
+    && a.moduleDepth === b.moduleDepth;
+}
+

--- a/lib/resolvers/auto.js
+++ b/lib/resolvers/auto.js
@@ -39,11 +39,10 @@ module.exports = function(container) {
     }
 
     candidates = candidates.sort(scoreCandidates);
-
     if ( candidates.length > 1 && equalCandidates(candidates[0], candidates[1]) ) {
       throw new Error('Multiple same rank objects implement interface \"' + iface + '\" required by \"' + (pid || 'unknown') + '\". Configure or remove one of: ' + candidates.map((ea)=>ea.id).join(', '));
     } else {
-      return candidates[0].id;
+      return (candidates[0] || {}).id;
     }
   };
 }

--- a/lib/utils/findpackages.js
+++ b/lib/utils/findpackages.js
@@ -1,30 +1,25 @@
 var path = require('path')
-  , pkginfo = require('pkginfo');
-
+  , glob = require('glob')
+  , fs = require('fs');
 
 exports = module.exports = function findAssemblies(cb) {
-  var app = pkginfo.find(require.main)
-    , deps = Object.keys(app.dependencies || {})
-    , nmdir = require.main.paths[0]
-    , asms = []
-    , dep, pkg;
-  
-  var i, len;
-  for (i = 0, len = deps.length; i < len; ++i) {
-    dep = deps[i];
-    pkg = pkginfo.find(null, path.join(nmdir, dep));
-    
-    if (pkg.assembly) {
-      asms.push({
-        name: pkg.name,
-        main: pkg.main,
-        assembly: pkg.assembly
-      });
+  glob('**/package.json', {cwd: path.dirname(require.main.filename)}, function collectAssembles (err, deps) {
+    var asms = [] 
+      , pkg;
+
+    var i, len;
+    for (i = 0, len = deps.length; i < len; ++i) {
+      pkg = JSON.parse(fs.readFileSync(deps[i]))
+      if (pkg.assembly) {
+        asms.push({
+          name: pkg.name,
+          main: pkg.main,
+          assembly: pkg.assembly
+        });
+      }
     }
-  }
+    cb(null, asms)
+  })
   
-  process.nextTick(function() {
-    cb(null, asms);
-  });
   return;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,595 @@
+{
+  "name": "bixby",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "canonical-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz",
+      "integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "electrolyte": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/electrolyte/-/electrolyte-0.5.0.tgz",
+      "integrity": "sha1-VIG6Em+MkOQ8IHu06vH799ayuPI=",
+      "requires": {
+        "canonical-path": "0.0.2",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "promise": "7.3.1",
+        "scripts": "0.1.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "requires": {
+        "locate-path": "2.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "make-node": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/make-node/-/make-node-0.3.5.tgz",
+      "integrity": "sha1-LTVN240+zfWg1btMrbuqRGHK3jo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+    },
+    "parent-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
+      "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "requires": {
+        "error-ex": "1.3.1",
+        "json-parse-better-errors": "1.0.2"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
+    "path-extra": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/path-extra/-/path-extra-1.0.3.tgz",
+      "integrity": "sha1-fBEhiablDVlXkOetIDfkTkEMEWY="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "requires": {
+        "pify": "3.0.0"
+      }
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "requires": {
+        "find-up": "2.1.0"
+      }
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "requires": {
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "3.0.0"
+      }
+    },
+    "recur-fs": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/recur-fs/-/recur-fs-2.2.4.tgz",
+      "integrity": "sha1-TcRRXqvcEZw9kUAkrFNTwC00oxg=",
+      "requires": {
+        "minimatch": "3.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.5.4"
+      }
+    },
+    "require-resolve": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/require-resolve/-/require-resolve-0.0.2.tgz",
+      "integrity": "sha1-urQQqxruLz9Vt5MXRR3TQodk5vM=",
+      "requires": {
+        "x-path": "0.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "scripts": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/scripts/-/scripts-0.1.0.tgz",
+      "integrity": "sha1-PrGXE7WtH1i8PjnOY2Bta+qgBpM="
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "toml": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "utils-flatten": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-flatten/-/utils-flatten-1.0.0.tgz",
+      "integrity": "sha1-AfMNMZO+RkxAsxdV5nQNDbDO8kM="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "requires": {
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "x-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/x-path/-/x-path-0.0.2.tgz",
+      "integrity": "sha1-KU0Ha7l6dwbMBwu7Km/YxU32exI=",
+      "requires": {
+        "path-extra": "1.0.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,8 +28,12 @@
   "dependencies": {
     "electrolyte": "^0.5.0",
     "parent-require": "^1.0.0",
+    "pkg-dir": "^2.0.0",
     "pkginfo": "^0.4.0",
+    "read-pkg-up": "^3.0.0",
     "recur-fs": "^2.2.4",
+    "require-resolve": "0.0.2",
+    "scripts": "^0.1.0",
     "toml": "^2.3.0",
     "utils-flatten": "^1.0.0"
   },


### PR DESCRIPTION
This pull request extends autoresolve such that duplicate implementations are resolved based on directory or module depth. Module depth is calculated by following the _required_by key in node_modules, and directory depth is calculated by counting the separators of a full path string and subtracting the root directory depth.

